### PR TITLE
add connect and login interface to the napery-tiled GUI

### DIFF
--- a/src/napari_tiled_browser/config.py
+++ b/src/napari_tiled_browser/config.py
@@ -1,0 +1,64 @@
+"""Persistent configuration for napari-tiled.
+
+Stores and loads user settings (URL, username) from a YAML file
+in the platform-appropriate config directory.
+"""
+
+import logging
+from pathlib import Path
+
+import platformdirs
+import yaml
+
+_logger = logging.getLogger(__name__)
+
+CONFIG_DIR = Path(platformdirs.user_config_dir("napari-tiled"))
+CONFIG_FILE = CONFIG_DIR / "config.yaml"
+_BUNDLED_CONFIG = Path(__file__).parent / "config.yaml"
+
+
+def load_config() -> dict:
+    """Load configuration from config.yaml.
+
+    Checks the user config directory first, then falls back to the
+    bundled config.yaml shipped with the package.
+    Returns an empty dict if neither exists or is invalid.
+    """
+    for path in (CONFIG_FILE, _BUNDLED_CONFIG):
+        if path.exists():
+            try:
+                with open(path) as f:
+                    data = yaml.safe_load(f)
+                if isinstance(data, dict):
+                    return data
+            except Exception:
+                _logger.warning("Failed to read config from %s", path)
+    return {}
+
+
+def save_config(config: dict) -> None:
+    """Save configuration to config.yaml."""
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(CONFIG_FILE, "w") as f:
+            yaml.safe_dump(config, f, default_flow_style=False)
+    except Exception:
+        _logger.warning("Failed to write config to %s", CONFIG_FILE)
+
+
+def get_saved_url() -> str:
+    """Return the saved URL, or empty string."""
+    return load_config().get("url", "")
+
+
+def get_saved_username() -> str:
+    """Return the saved username, or empty string."""
+    return load_config().get("username", "")
+
+
+def save_login_info(url: str, username: str) -> None:
+    """Save the login URL and username to config.yaml."""
+    config = load_config()
+    config["url"] = url
+    config["username"] = username
+    save_config(config)

--- a/src/napari_tiled_browser/config.yaml
+++ b/src/napari_tiled_browser/config.yaml
@@ -1,0 +1,5 @@
+# napari-tiled configuration
+# This file stores login settings and is updated automatically on successful authentication.
+
+url: "https://tiled.nsls2.bnl.gov"
+username: "xyang4"

--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -19,6 +19,8 @@ from tiled.client.context import Context, handle_error, password_grant
 from tiled.queries import FullText, Key, Regex
 from tiled.structures.core import StructureFamily
 
+from napari_tiled_browser.config import save_login_info
+
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.DEBUG)
 
@@ -257,8 +259,10 @@ class TiledSelector:
                     identity_id = identity.get(
                         "id", identity.get("uuid", "")
                     )
+                    save_login_info(self.url, str(identity_id))
                     self.auth_success.emit(str(identity_id))
                 except Exception:
+                    save_login_info(self.url, "")
                     self.auth_success.emit("")
                 return
 
@@ -302,6 +306,7 @@ class TiledSelector:
             self._node_path_parts_from_uri = node_path_parts
             self._finalize_connection()
             self.auth_success.emit("(API key)")
+            save_login_info(self.url, "(API key)")
         except Exception as exception:
             error_message = str(exception)
             _logger.error(error_message)
@@ -345,6 +350,7 @@ class TiledSelector:
             context.configure_auth(tokens, remember_me=True)
             self._finalize_connection()
             identity_id = tokens.get("identity", {}).get("id", username)
+            save_login_info(self.url, str(identity_id))
             self.auth_success.emit(str(identity_id))
         except httpx.HTTPStatusError as err:
             if err.response.status_code == httpx.codes.UNAUTHORIZED:
@@ -484,6 +490,7 @@ class TiledSelector:
             del self._device_code_oauth2_spec
 
             self._finalize_connection()
+            save_login_info(self.url, "(device code)")
             self.auth_success.emit("(device code)")
             return True  # Done
 

--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from datetime import date, datetime
@@ -7,11 +8,14 @@ from math import ceil
 from urllib.parse import ParseResult
 from urllib.parse import urlparse as _urlparse
 
+import httpx
 from httpx import ConnectError
 from qtpy.QtCore import QObject, Signal
 from tiled.client import from_uri
 from tiled.client.array import ArrayClient
 from tiled.client.base import BaseClient
+from tiled.client.constructors import from_context
+from tiled.client.context import Context, handle_error, password_grant
 from tiled.queries import FullText, Key, Regex
 from tiled.structures.core import StructureFamily
 
@@ -62,6 +66,29 @@ class TiledSelectorSignals(QObject):
         str,  # Error message
         name="TiledSelector.url_validation_error",
     )
+    # Authentication signals
+    auth_required = Signal(
+        bool,  # whether authentication is required
+        list,  # list of auth providers
+        name="TiledSelector.auth_required",
+    )
+    auth_success = Signal(
+        str,  # identity info
+        name="TiledSelector.auth_success",
+    )
+    auth_error = Signal(
+        str,  # error message
+        name="TiledSelector.auth_error",
+    )
+    auth_device_code = Signal(
+        str,  # authorization_uri
+        str,  # user_code
+        int,  # expires_in
+        name="TiledSelector.auth_device_code",
+    )
+    logged_out = Signal(
+        name="TiledSelector.logged_out",
+    )
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -101,6 +128,15 @@ class TiledSelector:
         self.table_changed = self.signals.table_changed
         self.url_changed = self.signals.url_changed
         self.url_validation_error = self.signals.url_validation_error
+        self.auth_required = self.signals.auth_required
+        self.auth_success = self.signals.auth_success
+        self.auth_error = self.signals.auth_error
+        self.auth_device_code = self.signals.auth_device_code
+        self.logged_out = self.signals.logged_out
+
+        # Authentication state
+        self._context = None
+        self._node_path_parts_from_uri = []
 
         # A buffer to receive updates while the URL is being edited
         self._url_buffer = self.url
@@ -177,15 +213,297 @@ class TiledSelector:
         self.url = new_url
 
     def on_connect_clicked(self, checked: bool = False):
-        """Handle a button click to connect to the Tiled client."""
+        """Handle a button click to connect to the Tiled client.
+
+        This creates a Context to probe the server's auth requirements,
+        then either connects directly (no auth) or emits auth_required
+        so the UI can prompt for credentials.
+        """
         _logger.debug("TiledSelector.on_connect_clicked()...")
 
         if self.client:
-            # TODO: Clean-up previously connected client?
-            ...
+            # Clean up previous client
+            self._context = None
+            self._client = None
 
-        self.connect_client()
+        try:
+            context, node_path_parts = Context.from_any_uri(self.url)
+        except (ConnectError, Exception) as exception:
+            error_message = str(exception)
+            _logger.error(error_message)
+            self.client_connection_error.emit(error_message)
+            return
+
+        self._context = context
+        self._node_path_parts_from_uri = node_path_parts
+
+        # Check server auth requirements
+        server_info = context.server_info
+        auth_is_required = server_info.authentication.required
+        providers = server_info.authentication.providers
+
+        if not auth_is_required and not providers:
+            # No auth needed, connect directly
+            self._finalize_connection()
+            return
+
+        if providers:
+            # Check for cached tokens first
+            found_valid_tokens = context.use_cached_tokens()
+            if found_valid_tokens:
+                self._finalize_connection()
+                try:
+                    identity = context.whoami()
+                    identity_id = identity.get(
+                        "id", identity.get("uuid", "")
+                    )
+                    self.auth_success.emit(str(identity_id))
+                except Exception:
+                    self.auth_success.emit("")
+                return
+
+        # Emit auth_required so the UI can display login options
+        self.auth_required.emit(auth_is_required, list(providers))
+
+        if not auth_is_required:
+            # Auth optional - still connect without auth
+            self._finalize_connection()
+
+    def _finalize_connection(self):
+        """Create a Tiled client from the existing context and emit connected."""
+        _logger.debug("TiledSelector._finalize_connection()...")
+        try:
+            new_client = from_context(
+                self._context,
+                node_path_parts=self._node_path_parts_from_uri,
+                remember_me=True,
+            )
+        except Exception as exception:
+            error_message = str(exception)
+            _logger.error(error_message)
+            self.client_connection_error.emit(error_message)
+            return
+
+        self._client = new_client
+        self.client_connected.emit(
+            self._client.uri, str(self._client.context.api_uri)
+        )
         self.reset_client_view()
+
+    def on_api_key_login(self, api_key: str):
+        """Authenticate with an API key and connect."""
+        _logger.debug("TiledSelector.on_api_key_login()...")
+
+        try:
+            context, node_path_parts = Context.from_any_uri(
+                self.url, api_key=api_key
+            )
+            self._context = context
+            self._node_path_parts_from_uri = node_path_parts
+            self._finalize_connection()
+            self.auth_success.emit("(API key)")
+        except Exception as exception:
+            error_message = str(exception)
+            _logger.error(error_message)
+            self.auth_error.emit(error_message)
+
+    def on_password_login(self, username: str, password: str):
+        """Authenticate with username/password and connect."""
+        _logger.debug("TiledSelector.on_password_login()...")
+
+        if self._context is None:
+            self.auth_error.emit("Not connected to a server. Click Connect first.")
+            return
+
+        context = self._context
+        providers = context.server_info.authentication.providers
+
+        # Find the internal/password provider
+        spec = None
+        for p in providers:
+            if p.mode in ("internal", "password"):
+                spec = p
+                break
+
+        if spec is None:
+            self.auth_error.emit(
+                "Server does not support password authentication."
+            )
+            return
+
+        auth_endpoint = spec.links["auth_endpoint"]
+        provider = spec.provider
+
+        try:
+            tokens = password_grant(
+                context.http_client,
+                auth_endpoint,
+                provider,
+                username,
+                password,
+            )
+            context.configure_auth(tokens, remember_me=True)
+            self._finalize_connection()
+            identity_id = tokens.get("identity", {}).get("id", username)
+            self.auth_success.emit(str(identity_id))
+        except httpx.HTTPStatusError as err:
+            if err.response.status_code == httpx.codes.UNAUTHORIZED:
+                self.auth_error.emit(
+                    "Username or password not recognized."
+                )
+            else:
+                self.auth_error.emit(str(err))
+        except Exception as exception:
+            self.auth_error.emit(str(exception))
+
+    def on_device_code_login(self):
+        """Start device code authentication flow."""
+        _logger.debug("TiledSelector.on_device_code_login()...")
+
+        if self._context is None:
+            self.auth_error.emit("Not connected to a server. Click Connect first.")
+            return
+
+        context = self._context
+        providers = context.server_info.authentication.providers
+
+        # Find the external provider
+        spec = None
+        for p in providers:
+            if p.mode == "external":
+                spec = p
+                break
+
+        if spec is None:
+            self.auth_error.emit(
+                "Server does not support device code authentication."
+            )
+            return
+
+        auth_endpoint = spec.links["auth_endpoint"]
+        client_id = spec.links.get("client_id")
+        token_endpoint = spec.links.get("token_endpoint")
+        oauth2_spec = bool(client_id and token_endpoint)
+
+        try:
+            # Request device code from server
+            if oauth2_spec:
+                verification_response = context.http_client.post(
+                    auth_endpoint,
+                    data={
+                        "client_id": client_id,
+                        "scope": "openid offline_access",
+                    },
+                )
+            else:
+                verification_response = context.http_client.post(
+                    auth_endpoint
+                )
+            handle_error(verification_response)
+            verification = verification_response.json()
+
+            uri_key = (
+                "verification_uri_complete"
+                if oauth2_spec
+                else "authorization_uri"
+            )
+            authorization_uri = verification[uri_key]
+            user_code = verification.get("user_code", "")
+            expires_in = int(verification.get("expires_in", 600))
+
+            # Emit signal so UI can display the code
+            self.auth_device_code.emit(
+                authorization_uri, user_code, expires_in
+            )
+
+            # Store verification data for polling
+            self._device_code_verification = verification
+            self._device_code_client_id = client_id
+            self._device_code_token_endpoint = token_endpoint
+            self._device_code_oauth2_spec = oauth2_spec
+
+        except Exception as exception:
+            self.auth_error.emit(str(exception))
+
+    def poll_device_code(self):
+        """Poll the server to check if the device code has been authorized.
+
+        Returns True if authorized, False if still pending,
+        and emits auth_error on failure.
+        """
+        if not hasattr(self, "_device_code_verification"):
+            return False
+
+        context = self._context
+        verification = self._device_code_verification
+        client_id = self._device_code_client_id
+        token_endpoint = self._device_code_token_endpoint
+        oauth2_spec = self._device_code_oauth2_spec
+
+        try:
+            if oauth2_spec:
+                access_response = context.http_client.post(
+                    token_endpoint,
+                    data={
+                        "device_code": verification["device_code"],
+                        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                        "client_id": client_id,
+                    },
+                )
+            else:
+                access_response = context.http_client.post(
+                    verification["verification_uri"],
+                    json={
+                        "device_code": verification["device_code"],
+                        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    },
+                    auth=None,
+                )
+
+            if access_response.status_code == httpx.codes.BAD_REQUEST:
+                error_data = access_response.json()
+                error_str = (
+                    error_data.get("error")
+                    if oauth2_spec
+                    else error_data.get("detail", {}).get("error")
+                )
+                if error_str == "authorization_pending":
+                    return False  # Still waiting
+                # Other error
+                self.auth_error.emit(f"Device code error: {error_str}")
+                return True  # Stop polling
+
+            handle_error(access_response)
+            tokens = access_response.json()
+            context.configure_auth(tokens, remember_me=True)
+
+            # Clean up verification data
+            del self._device_code_verification
+            del self._device_code_client_id
+            del self._device_code_token_endpoint
+            del self._device_code_oauth2_spec
+
+            self._finalize_connection()
+            self.auth_success.emit("(device code)")
+            return True  # Done
+
+        except Exception as exception:
+            self.auth_error.emit(str(exception))
+            return True  # Stop polling on error
+
+    def on_logout(self):
+        """Log out of the current session."""
+        _logger.debug("TiledSelector.on_logout()...")
+
+        if self._context is not None:
+            try:
+                self._context.logout()
+            except Exception as exception:
+                _logger.warning("Logout error: %s", exception)
+
+        self._client = None
+        self._context = None
+        self.logged_out.emit()
 
     def connect_client(self) -> None:
         """Connect the model's Tiled client to the Tiled server at URL.

--- a/src/napari_tiled_browser/qt/tiled_login.py
+++ b/src/napari_tiled_browser/qt/tiled_login.py
@@ -1,0 +1,272 @@
+"""Login widget for Tiled authentication.
+
+Provides a Qt-based login dialog that supports:
+- API key authentication
+- Username/password (internal) authentication
+- Device code (external/OAuth2) authentication
+"""
+
+import logging
+import webbrowser
+
+from qtpy.QtCore import QTimer, Signal
+from qtpy.QtWidgets import (
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class QTiledLoginWidget(QWidget):
+    """Widget for handling Tiled server authentication.
+
+    Emits signals for the different authentication methods
+    so the model can perform the actual authentication.
+    """
+
+    api_key_submitted = Signal(str)  # api_key
+    password_submitted = Signal(str, str)  # username, password
+    login_requested = Signal()
+    logout_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._create_layout()
+
+    def _create_layout(self):
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Auth method selector
+        method_layout = QHBoxLayout()
+        method_layout.addWidget(QLabel("Auth:"))
+        self.auth_method_selector = QComboBox()
+        self.auth_method_selector.addItems(
+            ["None", "API Key", "Password", "Device Code"]
+        )
+        method_layout.addWidget(self.auth_method_selector)
+
+        # Status label
+        self.status_label = QLabel("")
+        method_layout.addWidget(self.status_label)
+        method_layout.addStretch()
+        main_layout.addLayout(method_layout)
+
+        # Stacked widget for different auth forms
+        self.auth_stack = QStackedWidget()
+
+        # Page 0: No auth (empty)
+        self.auth_stack.addWidget(QWidget())
+
+        # Page 1: API Key
+        self.auth_stack.addWidget(self._create_api_key_page())
+
+        # Page 2: Password
+        self.auth_stack.addWidget(self._create_password_page())
+
+        # Page 3: Device Code
+        self.auth_stack.addWidget(self._create_device_code_page())
+
+        main_layout.addWidget(self.auth_stack)
+
+        # Login / Logout buttons
+        button_layout = QHBoxLayout()
+        self.login_button = QPushButton("Login")
+        self.logout_button = QPushButton("Logout")
+        self.logout_button.setEnabled(False)
+        button_layout.addWidget(self.login_button)
+        button_layout.addWidget(self.logout_button)
+        button_layout.addStretch()
+        main_layout.addLayout(button_layout)
+
+        self.setLayout(main_layout)
+
+        # Connections
+        self.auth_method_selector.currentIndexChanged.connect(
+            self.auth_stack.setCurrentIndex
+        )
+        self.login_button.clicked.connect(self._on_login_clicked)
+        self.logout_button.clicked.connect(self._on_logout_clicked)
+
+    def _create_api_key_page(self):
+        page = QWidget()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(QLabel("API Key:"))
+        self.api_key_entry = QLineEdit()
+        self.api_key_entry.setEchoMode(QLineEdit.EchoMode.Password)
+        self.api_key_entry.setPlaceholderText("Enter API key")
+        layout.addWidget(self.api_key_entry)
+        page.setLayout(layout)
+        return page
+
+    def _create_password_page(self):
+        page = QWidget()
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(QLabel("Username:"))
+        self.username_entry = QLineEdit()
+        self.username_entry.setPlaceholderText("Username")
+        layout.addWidget(self.username_entry)
+        layout.addWidget(QLabel("Password:"))
+        self.password_entry = QLineEdit()
+        self.password_entry.setEchoMode(QLineEdit.EchoMode.Password)
+        self.password_entry.setPlaceholderText("Password")
+        layout.addWidget(self.password_entry)
+        page.setLayout(layout)
+        return page
+
+    def _create_device_code_page(self):
+        page = QWidget()
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.device_code_info = QLabel(
+            "Click Login to start device code authentication."
+        )
+        self.device_code_info.setWordWrap(True)
+        layout.addWidget(self.device_code_info)
+
+        code_layout = QHBoxLayout()
+        self.device_code_label = QLabel("")
+        self.device_code_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        code_layout.addWidget(self.device_code_label)
+        self.open_browser_button = QPushButton("Open Browser")
+        self.open_browser_button.setVisible(False)
+        self.open_browser_button.clicked.connect(self._on_open_browser)
+        code_layout.addWidget(self.open_browser_button)
+        code_layout.addStretch()
+        layout.addLayout(code_layout)
+
+        self.device_code_status = QLabel("")
+        layout.addWidget(self.device_code_status)
+
+        page.setLayout(layout)
+        return page
+
+    def _on_login_clicked(self):
+        method_index = self.auth_method_selector.currentIndex()
+        if method_index == 1:  # API Key
+            api_key = self.api_key_entry.text().strip()
+            if api_key:
+                self.api_key_submitted.emit(api_key)
+        elif method_index == 2:  # Password
+            username = self.username_entry.text().strip()
+            password = self.password_entry.text().strip()
+            if username and password:
+                self.password_submitted.emit(username, password)
+        elif method_index == 3:  # Device Code
+            self.login_requested.emit()
+        else:
+            # No auth - just emit login request so connection proceeds
+            self.login_requested.emit()
+
+    def _on_logout_clicked(self):
+        self.logout_requested.emit()
+
+    def _on_open_browser(self):
+        url = self._authorization_uri
+        if url:
+            webbrowser.open(url)
+
+    # --- Methods called by the main widget to update UI state ---
+
+    def set_auth_status(self, text, is_error=False):
+        """Update the auth status label."""
+        if is_error:
+            self.status_label.setStyleSheet("color: red;")
+        else:
+            self.status_label.setStyleSheet("color: green;")
+        self.status_label.setText(text)
+
+    def set_logged_in(self, identity_info=""):
+        """Update UI to reflect logged-in state."""
+        self.login_button.setEnabled(False)
+        self.logout_button.setEnabled(True)
+        self.auth_method_selector.setEnabled(False)
+        if identity_info:
+            self.set_auth_status(f"Logged in as {identity_info}")
+        else:
+            self.set_auth_status("Authenticated")
+
+    def set_logged_out(self):
+        """Update UI to reflect logged-out state."""
+        self.login_button.setEnabled(True)
+        self.logout_button.setEnabled(False)
+        self.auth_method_selector.setEnabled(True)
+        self.status_label.setText("")
+        self.status_label.setStyleSheet("")
+        # Reset device code UI
+        self.device_code_info.setText(
+            "Click Login to start device code authentication."
+        )
+        self.device_code_label.setText("")
+        self.device_code_status.setText("")
+        self.open_browser_button.setVisible(False)
+
+    def show_device_code(self, authorization_uri, user_code, expires_in):
+        """Display device code flow information."""
+        self._authorization_uri = authorization_uri
+        minutes = int(expires_in) // 60
+        self.device_code_info.setText(
+            f"You have {minutes} minutes to visit the URL and enter the code:"
+        )
+        self.device_code_label.setText(user_code)
+        self.open_browser_button.setVisible(True)
+        self.device_code_status.setText("Waiting for authorization...")
+
+    def show_device_code_polling(self):
+        """Update status during device code polling."""
+        self.device_code_status.setText("Waiting for authorization...")
+
+    def set_auth_providers(self, providers):
+        """Configure available auth methods based on server capabilities.
+
+        Parameters
+        ----------
+        providers : list
+            List of AboutAuthenticationProvider from the server.
+        """
+        self.auth_method_selector.blockSignals(True)
+        self.auth_method_selector.clear()
+        self.auth_method_selector.addItem("None")
+
+        # Always allow API Key
+        self.auth_method_selector.addItem("API Key")
+
+        has_internal = False
+        has_external = False
+        for p in providers:
+            mode = p.mode
+            if mode in ("internal", "password"):
+                has_internal = True
+            elif mode == "external":
+                has_external = True
+
+        if has_internal:
+            self.auth_method_selector.addItem("Password")
+        if has_external:
+            self.auth_method_selector.addItem("Device Code")
+
+        # Auto-select if only one provider type
+        if len(providers) == 1:
+            mode = providers[0].mode
+            if mode in ("internal", "password"):
+                idx = self.auth_method_selector.findText("Password")
+                self.auth_method_selector.setCurrentIndex(idx)
+            elif mode == "external":
+                idx = self.auth_method_selector.findText("Device Code")
+                self.auth_method_selector.setCurrentIndex(idx)
+
+        self.auth_method_selector.blockSignals(False)
+        self.auth_stack.setCurrentIndex(
+            self.auth_method_selector.currentIndex()
+        )

--- a/src/napari_tiled_browser/qt/tiled_widget.py
+++ b/src/napari_tiled_browser/qt/tiled_widget.py
@@ -13,7 +13,7 @@ import os
 from datetime import date, datetime
 
 from napari.resources._icons import ICONS
-from qtpy.QtCore import Qt, QThreadPool, Signal
+from qtpy.QtCore import Qt, QThreadPool, QTimer, Signal
 from qtpy.QtGui import QIcon, QPixmap
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -38,6 +38,7 @@ from tiled.structures.core import StructureFamily
 from napari_tiled_browser.models.tiled_selector import TiledSelector
 from napari_tiled_browser.models.tiled_subscriber import SubscriptionManager
 from napari_tiled_browser.models.tiled_worker import TiledWorker
+from napari_tiled_browser.qt.tiled_login import QTiledLoginWidget
 from napari_tiled_browser.qt.tiled_search import QTiledSearchWidget
 
 _logger = logging.getLogger(__name__)
@@ -108,11 +109,21 @@ class QTiledBrowser(QWidget):
         self.connection_label = QLabel("No url connected")
         self.connection_widget = QWidget()
 
+        # Login widget
+        self.login_widget = QTiledLoginWidget()
+        self.login_widget.setVisible(False)
+
+        # Device code polling timer
+        self._device_code_timer = QTimer()
+        self._device_code_timer.setInterval(5000)
+        self._device_code_timer.timeout.connect(self._poll_device_code)
+
         # Connection layout
         connection_layout = QVBoxLayout()
         connection_layout.addWidget(self.url_entry)
         connection_layout.addWidget(self.connect_button)
         connection_layout.addWidget(self.connection_label)
+        connection_layout.addWidget(self.login_widget)
         connection_layout.addStretch()
         self.connection_widget.setLayout(connection_layout)
 
@@ -334,12 +345,54 @@ class QTiledBrowser(QWidget):
         @self.model.client_connected.connect
         def on_client_connected(url: str, api_url: str):
             self.connection_label.setText(f"Connected to {url}")
-            # TODO: Display the contents of the Tiled node
 
         @self.model.client_connection_error.connect
         def on_client_connection_error(error_msg: str):
-            # TODO: Display the error message; suggest a remedy
-            ...
+            self.connection_label.setText(f"Error: {error_msg}")
+            self.login_widget.set_auth_status(error_msg, is_error=True)
+
+        @self.model.auth_required.connect
+        def on_auth_required(required: bool, providers: list):
+            self.login_widget.setVisible(True)
+            self.login_widget.set_auth_providers(providers)
+            if required:
+                self.connection_label.setText(
+                    "Authentication required. Please log in."
+                )
+            else:
+                self.connection_label.setText(
+                    "Connected (authentication available)"
+                )
+
+        @self.model.auth_success.connect
+        def on_auth_success(identity_info: str):
+            self.login_widget.set_logged_in(identity_info)
+            self._device_code_timer.stop()
+
+        @self.model.auth_error.connect
+        def on_auth_error(error_msg: str):
+            self.login_widget.set_auth_status(error_msg, is_error=True)
+            self._device_code_timer.stop()
+
+        @self.model.auth_device_code.connect
+        def on_auth_device_code(
+            authorization_uri: str, user_code: str, expires_in: int
+        ):
+            self.login_widget.show_device_code(
+                authorization_uri, user_code, expires_in
+            )
+            import webbrowser
+
+            webbrowser.open(authorization_uri)
+            # Start polling for authorization
+            self._device_code_timer.start()
+
+        @self.model.logged_out.connect
+        def on_logged_out():
+            self.login_widget.set_logged_out()
+            self.connection_label.setText("Logged out")
+            self.search_widget.setVisible(False)
+            self.catalog_table_widget.setVisible(False)
 
         @self.model.table_changed.connect
         def on_table_changed(node_path_parts: tuple[str]):
@@ -383,6 +436,35 @@ class QTiledBrowser(QWidget):
         self.rows_per_page_selector.currentIndexChanged.connect(
             self.model.on_rows_per_page_changed
         )
+
+        # Login widget signals
+        self.login_widget.api_key_submitted.connect(
+            self.model.on_api_key_login
+        )
+        self.login_widget.password_submitted.connect(
+            self.model.on_password_login
+        )
+        self.login_widget.login_requested.connect(
+            self._on_login_requested
+        )
+        self.login_widget.logout_requested.connect(
+            self.model.on_logout
+        )
+
+    def _on_login_requested(self):
+        """Handle a generic login request from the login widget."""
+        method_text = self.login_widget.auth_method_selector.currentText()
+        if method_text == "Device Code":
+            self.model.on_device_code_login()
+        else:
+            # For "None" auth, just re-trigger connect
+            self.model.on_connect_clicked()
+
+    def _poll_device_code(self):
+        """Poll for device code authorization completion."""
+        done = self.model.poll_device_code()
+        if done:
+            self._device_code_timer.stop()
 
     def connect_self_signals(self):
         self.load_button.clicked.connect(self._on_load)

--- a/src/napari_tiled_browser/qt/tiled_widget.py
+++ b/src/napari_tiled_browser/qt/tiled_widget.py
@@ -35,6 +35,7 @@ from tiled.client.container import Container
 from tiled.profiles import load_profiles
 from tiled.structures.core import StructureFamily
 
+from napari_tiled_browser.config import get_saved_url, get_saved_username
 from napari_tiled_browser.models.tiled_selector import TiledSelector
 from napari_tiled_browser.models.tiled_subscriber import SubscriptionManager
 from napari_tiled_browser.models.tiled_worker import TiledWorker
@@ -88,6 +89,12 @@ class QTiledBrowser(QWidget):
         profiles = load_profiles()
         _, profile_details = profiles.get(profile, (None, {}))
         url = profile_details.get("uri", default_url)
+
+        # Fall back to saved config if no URL from profile/env
+        if not url:
+            url = get_saved_url()
+        self._saved_username = get_saved_username()
+
         _logger.debug("Will attempt to connect to Tiled at %s", url)
 
         self.model = TiledSelector(url=url)
@@ -480,6 +487,9 @@ class QTiledBrowser(QWidget):
     def initialize_values(self):
         self.reset_url_entry()
         self.reset_rows_per_page()
+        # Pre-fill saved username in login widget
+        if self._saved_username:
+            self.login_widget.username_entry.setText(self._saved_username)
 
     def _on_catalog_live_button_clicked(self):
         # TODO: add check for CatalogOfBlueskyRuns and enable/disable live button as needed


### PR DESCRIPTION

1. User enters a URL and clicks **Connect**
2. The model creates a `Context`, probes the server, and checks auth requirements
3. If cached tokens exist and are valid, the connection proceeds automatically
4. If auth is required (or available), the login widget appears with server-supported methods
5. User selects a method and provides credentials → model authenticates → UI updates to logged-in state
6. URL and username are saved to config.yaml for next session
7. User can click **Logout** to revoke the session and clear tokens