### PR TITLE
Only search on CatalogOfBlueskyRuns; clear search results otherwise

### DIFF
--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -7,7 +7,6 @@ from math import ceil
 from urllib.parse import ParseResult
 from urllib.parse import urlparse as _urlparse
 
-from bluesky_tiled_plugins import BlueskyRun
 from httpx import ConnectError
 from qtpy.QtCore import QObject, Signal
 from tiled.client import from_uri
@@ -154,6 +153,15 @@ class TiledSelector:
             return len(self.search_results)
         else:
             return len(self.get_current_node())
+
+    def is_catalog_of_bluesky_runs(self, node):
+        specs = node.item["attributes"]["specs"]
+        for spec in specs:
+            if spec["name"] == "CatalogOfBlueskyRuns":
+                return True
+            else:
+                pass
+        return False
 
     def on_url_text_edited(self, new_text: str):
         """Handle a notification that the URL is being edited."""
@@ -327,13 +335,12 @@ class TiledSelector:
         self.node_path_parts += (child_node_path,)
         self._current_page = 0
 
-        run = self.client[self.node_path_parts]
-        if isinstance(run, BlueskyRun):
-            # If we are in a BlueskyRun, don't display search results
-            self.display_search_results = False
-        else:
-            # Otherwise, display last search results
+        node = self.client[self.node_path_parts]
+        if self.is_catalog_of_bluesky_runs(node):
+            # Only display search results if we are in a CatalogOfBlueskyRuns
             self.display_search_results = True
+        else:
+            self.display_search_results = False
         self.table_changed.emit(self.node_path_parts)
 
     def exit_node(self) -> None:
@@ -343,11 +350,12 @@ class TiledSelector:
         _logger.info("Exiting node...")
         self.node_path_parts = self.node_path_parts[:-1]
         self._current_page = 0
-        run = self.client[self.node_path_parts]
-        if isinstance(run, BlueskyRun):
-            self.display_search_results = False
-        else:
+        node = self.client[self.node_path_parts]
+        if self.is_catalog_of_bluesky_runs(node):
+            # Only display search results if we are in a CatalogOfBlueskyRuns
             self.display_search_results = True
+        else:
+            self.display_search_results = False
         self.table_changed.emit(self.node_path_parts)
 
     def jump_to_node(self, index) -> None:
@@ -357,11 +365,12 @@ class TiledSelector:
         _logger.info("Jumping to node at index %d...", index)
         self.node_path_parts = self.node_path_parts[:index]
         self._current_page = 0
-        run = self.client[self.node_path_parts]
-        if isinstance(run, BlueskyRun):
-            self.display_search_results = False
-        else:
+        node = self.client[self.node_path_parts]
+        if self.is_catalog_of_bluesky_runs(node):
+            # Only display search results if we are in a CatalogOfBlueskyRuns
             self.display_search_results = True
+        else:
+            self.display_search_results = False
         self.table_changed.emit(self.node_path_parts)
 
     def open_node(self, child_node_path: str) -> None:
@@ -386,15 +395,13 @@ class TiledSelector:
             _client = self.client[self.node_path_parts]
         else:
             _client = self.client
+        self.display_search_results = True
         if search_type == "key_value":
             results = _client.search(Key(key) == value)
-            self.display_search_results = True
         elif search_type == "full_text":
             results = _client.search(FullText(value))
-            self.display_search_results = True
         elif search_type == "regex":
             results = _client.search(Regex(key, pattern=value))
-            self.display_search_results = True
         else:
             _logger.info("Unknown search type %s. Returning...", search_type)
             results = None

--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -7,6 +7,7 @@ from math import ceil
 from urllib.parse import ParseResult
 from urllib.parse import urlparse as _urlparse
 
+from bluesky_tiled_plugins import BlueskyRun
 from httpx import ConnectError
 from qtpy.QtCore import QObject, Signal
 from tiled.client import from_uri
@@ -324,6 +325,11 @@ class TiledSelector:
         _logger.info("Entering node...")
         self.node_path_parts += (child_node_path,)
         self._current_page = 0
+
+        run = self.client[self.node_path_parts]
+        if isinstance(run, BlueskyRun):
+            # If we are in a BlueskyRun, clear search results
+            self.search_results = None
         self.table_changed.emit(self.node_path_parts)
 
     def exit_node(self) -> None:

--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -114,6 +114,7 @@ class TiledSelector:
             self._rows_per_page_options = rows_per_page_options
         self._rows_per_page_index = 0
         self.search_results = None
+        self.display_search_results = False
 
     @property
     def url(self) -> str:
@@ -149,10 +150,10 @@ class TiledSelector:
     @property
     def node_len(self):
         """Convenience function for returning total length of node/search result."""
-        if self.search_results is None:
-            return len(self.get_current_node())
-        else:
+        if self.search_results and self.display_search_results:
             return len(self.search_results)
+        else:
+            return len(self.get_current_node())
 
     def on_url_text_edited(self, new_text: str):
         """Handle a notification that the URL is being edited."""
@@ -328,8 +329,11 @@ class TiledSelector:
 
         run = self.client[self.node_path_parts]
         if isinstance(run, BlueskyRun):
-            # If we are in a BlueskyRun, clear search results
-            self.search_results = None
+            # If we are in a BlueskyRun, don't display search results
+            self.display_search_results = False
+        else:
+            # Otherwise, display last search results
+            self.display_search_results = True
         self.table_changed.emit(self.node_path_parts)
 
     def exit_node(self) -> None:
@@ -339,6 +343,11 @@ class TiledSelector:
         _logger.info("Exiting node...")
         self.node_path_parts = self.node_path_parts[:-1]
         self._current_page = 0
+        run = self.client[self.node_path_parts]
+        if isinstance(run, BlueskyRun):
+            self.display_search_results = False
+        else:
+            self.display_search_results = True
         self.table_changed.emit(self.node_path_parts)
 
     def jump_to_node(self, index) -> None:
@@ -348,6 +357,11 @@ class TiledSelector:
         _logger.info("Jumping to node at index %d...", index)
         self.node_path_parts = self.node_path_parts[:index]
         self._current_page = 0
+        run = self.client[self.node_path_parts]
+        if isinstance(run, BlueskyRun):
+            self.display_search_results = False
+        else:
+            self.display_search_results = True
         self.table_changed.emit(self.node_path_parts)
 
     def open_node(self, child_node_path: str) -> None:
@@ -374,13 +388,17 @@ class TiledSelector:
             _client = self.client
         if search_type == "key_value":
             results = _client.search(Key(key) == value)
+            self.display_search_results = True
         elif search_type == "full_text":
             results = _client.search(FullText(value))
+            self.display_search_results = True
         elif search_type == "regex":
             results = _client.search(Regex(key, pattern=value))
+            self.display_search_results = True
         else:
             _logger.info("Unknown search type %s. Returning...", search_type)
             results = None
+            self.display_search_results = False
         self.search_results = results
         self.table_changed.emit(self.node_path_parts)
 

--- a/src/napari_tiled_browser/models/tiled_selector.py
+++ b/src/napari_tiled_browser/models/tiled_selector.py
@@ -149,7 +149,7 @@ class TiledSelector:
     @property
     def node_len(self):
         """Convenience function for returning total length of node/search result."""
-        if self.search_results and self.display_search_results:
+        if self.search_results is not None and self.display_search_results:
             return len(self.search_results)
         else:
             return len(self.get_current_node())

--- a/src/napari_tiled_browser/models/tiled_worker.py
+++ b/src/napari_tiled_browser/models/tiled_worker.py
@@ -31,7 +31,7 @@ class TiledWorker(QRunnable):
         node_offset = self.rows_per_page * self.current_page
         selection = slice(node_offset, node_offset + self.rows_per_page)
 
-        if self.search_results and self.display_search_results:
+        if self.search_results is not None and self.display_search_results:
             catalog_or_search_results = self.search_results
             results = catalog_or_search_results.items()[selection]
         else:

--- a/src/napari_tiled_browser/models/tiled_worker.py
+++ b/src/napari_tiled_browser/models/tiled_worker.py
@@ -15,6 +15,7 @@ class TiledWorker(QRunnable):
         node_path_parts,
         rows_per_page,
         search_results,
+        display_search_results,
         **kwargs,
     ):
         super().__init__()
@@ -24,12 +25,16 @@ class TiledWorker(QRunnable):
         self.client = client
         self.search_results = search_results
         self.node_path_parts = node_path_parts
+        self.display_search_results = display_search_results
 
     def run(self):
         node_offset = self.rows_per_page * self.current_page
         selection = slice(node_offset, node_offset + self.rows_per_page)
 
-        if self.search_results is None:
+        if self.search_results and self.display_search_results:
+            catalog_or_search_results = self.search_results
+            results = catalog_or_search_results.items()[selection]
+        else:
             catalog_or_search_results = self.client
             if self.node_path_parts:
                 results = catalog_or_search_results[
@@ -37,9 +42,6 @@ class TiledWorker(QRunnable):
                 ].items()[selection]
             else:
                 results = catalog_or_search_results.items()[selection]
-        else:
-            catalog_or_search_results = self.search_results
-            results = catalog_or_search_results.items()[selection]
 
         self.signals.finished.emit()
         self.signals.results.emit(results)

--- a/src/napari_tiled_browser/qt/tiled_widget.py
+++ b/src/napari_tiled_browser/qt/tiled_widget.py
@@ -259,6 +259,7 @@ class QTiledBrowser(QWidget):
             client=self.model.client,
             search_results=self.model.search_results,
             node_path_parts=self.model.node_path_parts,
+            display_search_results=self.model.display_search_results,
         )
         runnable.signals.results.connect(self.populate_table)
         self.thread_pool.start(runnable)


### PR DESCRIPTION
# References and relevant issues
Closes #26.

# Description
Previously, we could not open a BlueskyRun when using the search feature to find specific scans. This PR only performs the search on the CatalogOfBlueskyRuns and clears the search results otherwise to allow proper navigation into nodes.